### PR TITLE
Remove typo trailing semi from COLOR_PLAYER4 definition

### DIFF
--- a/main/colors.h
+++ b/main/colors.h
@@ -6,5 +6,5 @@
     #define COLOR_PLAYER1   MAKECOLOR_5BIT_RGB(26,  0,      0)
     #define COLOR_PLAYER2   MAKECOLOR_5BIT_RGB(31,  0,      31)
     #define COLOR_PLAYER3   MAKECOLOR_5BIT_RGB(31,  22,     0)
-    #define COLOR_PLAYER4   MAKECOLOR_5BIT_RGB(0,   27,     31);
+    #define COLOR_PLAYER4   MAKECOLOR_5BIT_RGB(0,   27,     31)
 #endif


### PR DESCRIPTION
Lucky break that this was only used benignly here...

    return COLOR_PLAYER4;

Bit me when I tried to condense `getColor()` into a lookup! :)