### PR TITLE
Free up 110 bytes using brutalization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,6 +66,7 @@
         "unordered_map": "cpp",
         "utility": "cpp",
         "vector": "cpp",
-        "list": "cpp"
+        "list": "cpp",
+        "random": "cpp"
     }
 }

--- a/main/action.cpp
+++ b/main/action.cpp
@@ -2,11 +2,37 @@
 
 namespace action {
 
-    byte prev_type;
-    byte prev_payload;
+
+    bool inline send(const byte type, const byte payload , const byte face) {
+
+        if(isValueReceivedOnFaceExpired(face)) {
+            return false;
+        }
+
+        uint16_t packet = type | ( ( (uint16_t) payload ) << 8 ); 
+
+        sendDatagramOnFace( &packet , sizeof(packet), face);
+
+        return true;            
+
+    }
+
+    byte prev_broadcast_type;
+    byte prev_broadcast_payload;
+
+    inline void broadcast(const byte type, const byte payload ) {
+
+        FOREACH_FACE(f) {
+            send( type , payload , f );
+        }
+
+        prev_broadcast_type    = type;
+        prev_broadcast_payload = payload;
+        
+    }    
 
     bool isBroadcastReceived(const Action& incoming, byte type){
-        if(incoming.type == type && ( prev_type != incoming.type || prev_payload != incoming.payload)) {
+        if(incoming.type == type && ( prev_broadcast_type != incoming.type || prev_broadcast_payload != incoming.payload)) {
             broadcast(incoming.type,incoming.payload);
             return true;
         }

--- a/main/action.cpp
+++ b/main/action.cpp
@@ -2,44 +2,15 @@
 
 namespace action {
 
-    byte cachedBroadcast[ACTION_LEN];
-    void broadcast(const Action& action){
-        encode(action, &cachedBroadcast[0]);
-        FOREACH_FACE(f){
-            send(action, f);
-        }
-    }
-
-    void reset(){
-        encode(Action{.type=0, .payload=0}, &cachedBroadcast[0]);
-    }
-
-    bool send(const Action& action, const byte face){
-        if(isValueReceivedOnFaceExpired(face)) {
-            return false;
-        }
-        byte data[ACTION_LEN];
-        encode(action, &data[0]);
-        sendDatagramOnFace(&data[0], sizeof(data), face);
-        return true;
-    }
-
-    void broadcastEmpty(const byte type){
-        broadcast(Action{.type = type, .payload=0});
-    }
+    byte prev_type;
+    byte prev_payload;
 
     bool isBroadcastReceived(const Action& incoming, byte type){
-        const Action cached = decode(&cachedBroadcast[0]);
-        if(incoming.type == type && (cached.type != incoming.type || cached.payload != incoming.payload)) {
-            broadcast(incoming);
+        if(incoming.type == type && ( prev_type != incoming.type || prev_payload != incoming.payload)) {
+            broadcast(incoming.type,incoming.payload);
             return true;
         }
         return false;
-    }
-
-    void encode(const Action& action, byte* buffer){
-        buffer[0] = action.type;
-        buffer[1] = action.payload;
     }
     
     Action decode(const byte* buffer){

--- a/main/action.cpp
+++ b/main/action.cpp
@@ -3,13 +3,16 @@
 namespace action {
 
 
-    bool inline send(const byte type, const byte payload , const byte face) {
+    bool send(const byte type, const byte payload , const byte face) {
 
         if(isValueReceivedOnFaceExpired(face)) {
             return false;
         }
 
-        uint16_t packet = type | ( ( (uint16_t) payload ) << 8 ); 
+        byte packet[ACTION_LEN];
+        
+        packet[0] = type;
+        packet[1] = payload; 
 
         sendDatagramOnFace( &packet , sizeof(packet), face);
 
@@ -20,7 +23,7 @@ namespace action {
     byte prev_broadcast_type;
     byte prev_broadcast_payload;
 
-    inline void broadcast(const byte type, const byte payload ) {
+    void broadcast(const byte type, const byte payload ) {
 
         FOREACH_FACE(f) {
             send( type , payload , f );
@@ -31,13 +34,28 @@ namespace action {
         
     }    
 
-    bool isBroadcastReceived(const Action& incoming, byte type){
+    bool isBroadcastReceived(const Action& incoming, const byte type){
         if(incoming.type == type && ( prev_broadcast_type != incoming.type || prev_broadcast_payload != incoming.payload)) {
             broadcast(incoming.type,incoming.payload);
             return true;
         }
         return false;
     }
+
+
+    bool isBroadcastReceived(const byte incoming_type , const byte incoming_payload, byte type) {
+        if( incoming_type == type && ( prev_broadcast_type != incoming_type || prev_broadcast_payload != incoming_payload)) {
+            broadcast(incoming_type,incoming_payload);
+            return true;
+        }
+        return false;
+    }
+
+    void encode(const Action& action, byte* buffer) {
+        buffer[0] = action.type;
+        buffer[1] = action.payload;
+    }
+
     
     Action decode(const byte* buffer){
         return Action{
@@ -45,5 +63,6 @@ namespace action {
             .payload=buffer[1]
         };
     }
+
 
 }

--- a/main/action.h
+++ b/main/action.h
@@ -13,28 +13,8 @@
 
         #define ACTION_LEN 2
 
-        bool inline send(const byte type, const byte payload , const byte face) {
-
-            if(isValueReceivedOnFaceExpired(face)) {
-                return false;
-            }
-
-            uint16_t packet = type | (payload << 8 ); 
-
-            sendDatagramOnFace( &packet , sizeof(packet), face);
-
-            return true;            
-
-        }
-
-        inline void broadcast(const byte type, const byte payload ) {
-
-            FOREACH_FACE(f) {
-                send( type , payload , f );
-            }
-            
-        }
-
+        void broadcast(const byte type, const byte payload );
+        bool send(const byte type, const byte payload , const byte face);
 
         bool isBroadcastReceived(const Action& action, const byte type);
         Action decode(const byte* buffer);

--- a/main/action.h
+++ b/main/action.h
@@ -16,13 +16,19 @@
         void broadcast(const byte type, const byte payload );
         bool send(const byte type, const byte payload , const byte face);
 
-        bool isBroadcastReceived(const Action& action, const byte type);
-        Action decode(const byte* buffer);
+        bool isBroadcastReceived(const Action& incoming, const byte type);
 
-        void inline encode(const Action& action, byte* buffer) {
-            buffer[0] = action.type;
-            buffer[1] = action.payload;
+        Action decode(const byte* buffer);
+        void encode(const Action& action, byte* buffer);
+        
+        byte inline decode_type( const byte* buffer) {
+            return buffer[0];
         }
+
+        byte inline decode_payload( const byte* buffer) {
+            return buffer[1];
+        }
+
 
 }
 

--- a/main/action.h
+++ b/main/action.h
@@ -6,19 +6,44 @@
     namespace action {
 
         struct Action {
+
             const byte type;
             const byte payload;
         };
 
         #define ACTION_LEN 2
 
-        void broadcast(const Action& action);
-        bool send(const Action& action, const byte face);
-        void reset();
-        void broadcastEmpty(const byte type);
+        bool inline send(const byte type, const byte payload , const byte face) {
+
+            if(isValueReceivedOnFaceExpired(face)) {
+                return false;
+            }
+
+            uint16_t packet = type | (payload << 8 ); 
+
+            sendDatagramOnFace( &packet , sizeof(packet), face);
+
+            return true;            
+
+        }
+
+        inline void broadcast(const byte type, const byte payload ) {
+
+            FOREACH_FACE(f) {
+                send( type , payload , f );
+            }
+            
+        }
+
+
         bool isBroadcastReceived(const Action& action, const byte type);
-        void encode(const Action& action, byte* buffer);
         Action decode(const byte* buffer);
+
+        void inline encode(const Action& action, byte* buffer) {
+            buffer[0] = action.type;
+            buffer[1] = action.payload;
+        }
+
 }
 
 #endif

--- a/main/distributed-task.cpp
+++ b/main/distributed-task.cpp
@@ -17,13 +17,13 @@ namespace distributedTask {
 
     void sendAllDone(byte requestType, byte taskValue){
         FOREACH_FACE(f){
-            action::send(action::Action{.type = static_cast<byte>(requestType+DONE_TYPE_OFFSET), .payload= taskValue}, f);
+            action::send( requestType+DONE_TYPE_OFFSET , taskValue , f);
         }
     }
     
     bool respondHandled(const stateCommon::LoopData& data, const byte requestType, taskHandler& handler){
         if (data.action.type == requestType) {
-            action::send(action::Action{.type = static_cast<byte>(requestType+RESP_TYPE_OFFSET), .payload=data.action.payload}, data.face);
+            action::send( (byte) (requestType+RESP_TYPE_OFFSET) , data.action.payload ,  data.face );
             return true;
         }
         return false;
@@ -31,7 +31,7 @@ namespace distributedTask {
 
     void sendBack(const byte requestType, taskHandler& handler, byte taskValue) {
         if(_incomingFace < FACE_COUNT) {
-            const bool sent = action::send(action::Action{.type = static_cast<byte>(requestType+RESP_TYPE_OFFSET), .payload=taskValue}, _incomingFace);
+            const bool sent = action::send( (byte)  requestType+RESP_TYPE_OFFSET ,   taskValue,   _incomingFace);
             _state = DISTRIBUTED_TASK_STATE_DONE;
             return;
         }
@@ -47,7 +47,7 @@ namespace distributedTask {
                 _outgoingFace = _outgoingFace + 1;
                 continue;    
             }
-            sent = action::send(action::Action{.type = requestType, .payload=taskValue}, _outgoingFace);
+            sent = action::send(  requestType, taskValue ,  _outgoingFace);
             if(!sent){
                 _outgoingFace = _outgoingFace + 1;
             }

--- a/main/global-events.cpp
+++ b/main/global-events.cpp
@@ -10,7 +10,7 @@ namespace globalEvents {
     bool _pendingReset = false;
 
     void changeAllToReset(){
-        action::broadcast(action::Action{.type=GAME_DEF_ACTION_RESET, .payload=millis()});
+        action::broadcast( (byte) GAME_DEF_ACTION_RESET,  (byte) millis() );
         stateBoard::reset();
         stateCommon::handleStateChange(GAME_DEF_STATE_DEFAULT);
     }

--- a/main/player.cpp
+++ b/main/player.cpp
@@ -4,15 +4,20 @@
 namespace player {
     
     Color getColor(const byte index) {
-        if(index == 0) {
-            return COLOR_PLAYER1;
+
+        switch( index ) {
+            
+            case 0 :
+                return COLOR_PLAYER1;
+            
+            case 1 : 
+                return COLOR_PLAYER2;
+            
+            case 2: 
+                return COLOR_PLAYER3;
+            
         }
-        if(index == 1) {
-            return COLOR_PLAYER2;
-        }
-        if(index == 2) {
-            return COLOR_PLAYER3;
-        }
+        
         return COLOR_PLAYER4;
     }
 }

--- a/main/state-board.cpp
+++ b/main/state-board.cpp
@@ -85,7 +85,7 @@ namespace stateBoard {
             }
             _viewState = VIEW_STATE_RADIATE;
             _playerToFaceRequests[_moveIndex] = data.face;
-            action::broadcast(action::Action{.type=GAME_DEF_ACTION_MOVE_TAKEN, .payload=_moveIndex});
+            action::broadcast(  GAME_DEF_ACTION_MOVE_TAKEN, _moveIndex );
         }
     }
 
@@ -112,7 +112,7 @@ namespace stateBoard {
             return;
         }
         if(buttonMultiClicked()){
-            action::broadcast(action::Action{.type=GAME_DEF_ACTION_END, .payload=millis()});
+            action::broadcast( GAME_DEF_ACTION_END,  millis() );
             _isEndInitiator = true;
             timer::cancel();
             stateCommon::handleStateChange(GAME_DEF_STATE_END);
@@ -123,7 +123,7 @@ namespace stateBoard {
                 stateCommon::handleStateChange(GAME_DEF_STATE_MOVER);
                 return;
             }
-            action::broadcast(action::Action{.type=GAME_DEF_ACTION_PROGRESS, .payload = millis()});
+            action::broadcast(  GAME_DEF_ACTION_PROGRESS,  millis() );
             changeToProgress();
         }
     }

--- a/main/state-mover.cpp
+++ b/main/state-mover.cpp
@@ -14,7 +14,7 @@ namespace stateMover {
     byte _currentPlayer = 0;
 
     void handleDelayedSend() {
-        action::send(action::Action{.type=GAME_DEF_ACTION_MOVE_REQUEST, .payload = _currentPlayer}, 0);
+        action::send( (byte) GAME_DEF_ACTION_MOVE_REQUEST,  _currentPlayer , 0);
     }
     
     void handleViewNormalize() {


### PR DESCRIPTION
An example of freeing up flash space by favoring compiler-friendly patterns. 

In this case, I ....

1. replaced a series of `if` statements with a `switch`
2. reworked parts of `Action` to favor register usage rather than memory usage 

It is not pretty, but when space is tight this technique can be useful.

I might have messed up somewhere, so please double check my work and also test that functionality is the same!

```
FLASH SIZE: 
BEFORE:5864
AFTER :5674
```

NB: Ignore the `does not work` comments, I misinterpreted how the game was supposed to work so I thought I broke something.  I do think (hope?) it works now!